### PR TITLE
Se actualizó WS que regresa la moneda de facturación

### DIFF
--- a/TurboERP_backend/src/main/java/com/turbomaquinas/service/general/LogicaOrdenService.java
+++ b/TurboERP_backend/src/main/java/com/turbomaquinas/service/general/LogicaOrdenService.java
@@ -180,6 +180,7 @@ public class LogicaOrdenService implements OrdenService{
 			mon.creado_por=orden.getCreado_por();
 			mon.fecha=orden.getCreado();
 			mon.tipo_cambio=1;
+			mon.tipo_cambio_calculado=1;
 			return mon;
 		}
 	}


### PR DESCRIPTION
http://localhost:8181/general/ordenes/{id}/monedafacturacion
Faltaba iniciar el tipo_cambio_calculado con 1 cuando la moneda sigue
siendo la original